### PR TITLE
Added case insensitivity flag to grep and replace regex

### DIFF
--- a/src/CalDAVClient.php
+++ b/src/CalDAVClient.php
@@ -179,10 +179,10 @@ class CalDAVClient {
       $headers = preg_split('/\r?\n/', $headers);
 
       // DAV header(s)
-      $dav_header = preg_grep('/^DAV:/', $headers);
+      $dav_header = preg_grep('/^DAV:/i', $headers);
       if (is_array($dav_header)) {
           $dav_header = array_values($dav_header);
-          $dav_header = preg_replace('/^DAV: /', '', $dav_header);
+          $dav_header = preg_replace('/^DAV: /i', '', $dav_header);
 
           $dav_options = array();
 


### PR DESCRIPTION
We recently recognized that our FreePBX instance is not syncing with our nextcloud calendar anymore and just returned a generic "Could not sync..." error.
We could trace the error back to a regular expression in line 182 and 185 in the CalDAVClient.php file which was case-sensitive. But headers in HTTP responses are case-insensitive. Our webserver responded with "Dav: ..." instead of "DAV: ..." which was expected by the DoOptionsRequestAndGetDAVHeader function.
We tested the changes with FreePBX and it resolved our issue and synced the calendars again.